### PR TITLE
Pool design bugs

### DIFF
--- a/DF/ops/pool_design.py
+++ b/DF/ops/pool_design.py
@@ -14,6 +14,8 @@ num_cores = 4
 # LOAD TABLES
 
 def validate_design(df_design):
+    if 0 in df_design['dialout'].values:
+        raise ValueError('dialout primers are one-indexed; value of 0 in "dialout" column is invalid.')
     for group, df in df_design.groupby('group'):
         x = df.drop_duplicates(['prefix_length', 'edit_distance'])
         if len(x) > 1:


### PR DESCRIPTION
Fixes a couple bugs I have run into in pool design:

1. discrepancies of whether dialout primers are 1- or 0-indexed. Here changed ops.pool_design.build_test to use 1-indexed dialout for consistency with ops.pool_design.build_sgRNA_oligos, changed example design.xlsx file to use 1-indexed dialouts, and added check for 0 in dialout column of design input table to enforce 1-indexed dialouts.
2. In ops.pool_design.maxy_clique_groups there is an edge case where index=0 doesn't meet the "if index" condition, resulting in a guide being selected but not included in the returned output